### PR TITLE
The lists is also the compiler.lists module

### DIFF
--- a/nimsuggest.nim
+++ b/nimsuggest.nim
@@ -9,10 +9,12 @@
 
 ## Nimsuggest is a tool that helps to give editors IDE like capabilities.
 
-import strutils, os, parseopt, parseUtils
+import strutils, os, parseopt, parseUtils, net, rdstdin
+
+# Modules which are included from the compiler sources
 import compiler/options, compiler/commands, compiler/modules, compiler/sem, 
   compiler/passes, compiler/passaux, compiler/msgs, compiler/nimconf,
-  compiler/extccomp, compiler/condsyms, lists, net, rdstdin
+  compiler/extccomp, compiler/condsyms, compiler/lists
 
 const Usage = """
 Nimsuggest - Tool to give every editor IDE like capabilities for Nim


### PR DESCRIPTION
Changed lists to reference the compiler lists module to avoid that it uses /pure/collections/lists instead. Grouped the modules by origin and added a comment to make clear that those are from the compiler sources.