### PR TITLE
Restructured files.

### DIFF
--- a/modes/commonMode.nim
+++ b/modes/commonMode.nim
@@ -1,0 +1,186 @@
+#
+#
+#           The Nim Compiler
+#        (c) Copyright 2015 Andreas Rumpf
+#
+#    See the file "copying.txt", included in this
+#    distribution, for details about the copyright.
+#
+
+## Nimsuggest is a tool that helps to give editors IDE like capabilities.
+
+import strutils, os, parseopt, parseutils, sequtils, net, rdstdin, ../sexp
+# Do NOT import suggest. It will lead to wierd bugs with
+# suggestionResultHook, because suggest.nim is included by sigmatch.
+# So we import that one instead.
+import ../nimsuggest
+import compiler/options, compiler/commands, compiler/modules, compiler/sem,
+  compiler/passes, compiler/passaux, compiler/msgs, compiler/nimconf,
+  compiler/extccomp, compiler/condsyms, compiler/lists,
+  compiler/sigmatch, compiler/ast
+
+when defined(windows):
+  import winlean
+else:
+  import posix
+
+const
+  seps = {':', ';', ' ', '\t'}
+  
+
+proc parseQuoted*(cmd: string; outp: var string; start: int): int =
+  var i = start
+  i += skipWhitespace(cmd, i)
+  if cmd[i] == '"':
+    i += parseUntil(cmd, outp, '"', i+1)+2
+  else:
+    i += parseUntil(cmd, outp, seps, i)
+  result = i
+
+proc connectToNextFreePort*(server: Socket, host: string, start = 30000): int =
+  result = start
+  while true:
+    try:
+      server.bindaddr(Port(result), host)
+      return
+    except OsError:
+      when defined(windows):
+        let checkFor = WSAEADDRINUSE.OSErrorCode
+      else:
+        let checkFor = EADDRINUSE.OSErrorCode
+      if osLastError() != checkFor:
+        raise getCurrentException()
+      else:
+        result += 1
+
+proc findNode(n: PNode): PSym =
+  #echo "checking node ", n.info
+  if n.kind == nkSym:
+    if isTracked(n.info, n.sym.name.s.len): return n.sym
+  else:
+    for i in 0 ..< safeLen(n):
+      let res = n.sons[i].findNode
+      if res != nil: return res
+
+proc symFromInfo(gTrackPos: TLineInfo): PSym =
+  let m = getModule(gTrackPos.fileIndex)
+  #echo m.isNil, " I knew it ", gTrackPos.fileIndex
+  if m != nil and m.ast != nil:
+    result = m.ast.findNode
+
+proc execute*(cmd: IdeCmd, file, dirtyfile: string, line, col: int) =
+  gIdeCmd = cmd
+  if cmd == ideUse and suggestVersion != 2:
+    modules.resetAllModules()
+  var isKnownFile = true
+  let dirtyIdx = file.fileInfoIdx(isKnownFile)
+
+  if dirtyfile.len != 0: msgs.setDirtyFile(dirtyIdx, dirtyfile)
+  else: msgs.setDirtyFile(dirtyIdx, nil)
+
+  gTrackPos = newLineInfo(dirtyIdx, line, col)
+  gErrorCounter = 0
+  if suggestVersion < 2:
+    usageSym = nil
+  if not isKnownFile:
+    compileProject()
+  if suggestVersion == 2 and gIdeCmd in {ideDef, ideUse, ideDus} and
+      dirtyfile.len == 0:
+    discard "no need to recompile anything"
+  else:
+    resetModule dirtyIdx
+    if dirtyIdx != gProjectMainIdx:
+      resetModule gProjectMainIdx
+    compileProject(dirtyIdx)
+  if gIdeCmd in {ideUse, ideDus}:
+    let u = if suggestVersion >= 2: symFromInfo(gTrackPos) else: usageSym
+    if u != nil:
+      discard
+      # EpcModeData(u)
+    else:
+      localError(gTrackPos, "found no symbol at this position " & $gTrackPos)
+
+proc parseCmdLine*(cmd: string) =
+  template toggle(sw) =
+    if sw in gGlobalOptions:
+      excl(gGlobalOptions, sw)
+    else:
+      incl(gGlobalOptions, sw)
+    return
+
+  template err() =
+    echo "Invalid Command"
+    return
+
+  var opc = ""
+  var i = parseIdent(cmd, opc, 0)
+  case opc.normalize
+  of "sug": gIdeCmd = ideSug
+  of "con": gIdeCmd = ideCon
+  of "def": gIdeCmd = ideDef
+  of "use": gIdeCmd = ideUse
+  of "dus": gIdeCmd = ideDus
+  of "chk":
+    gIdeCmd = ideChk
+    incl(gGlobalOptions, optIdeDebug)
+  of "highlight": gIdeCmd = ideHighlight
+  of "outline": gIdeCmd = ideOutline
+  of "quit": quit()
+  of "debug": toggle optIdeDebug
+  of "terse": toggle optIdeTerse
+  else: err()
+  var dirtyfile = ""
+  var orig = ""
+  i = parseQuoted(cmd, orig, i)
+  if cmd[i] == ';':
+    i = parseQuoted(cmd, dirtyfile, i+1)
+  i += skipWhile(cmd, seps, i)
+  var line = -1
+  var col = 0
+  i += parseInt(cmd, line, i)
+  i += skipWhile(cmd, seps, i)
+  i += parseInt(cmd, col, i)
+
+  execute(gIdeCmd, orig, dirtyfile, line, col-1)
+
+# proc serveEpc(server: Socket) =
+#   var inp = "".TaintedString
+#   var client = newSocket()
+#   # Wait for connection
+#   accept(server, client)
+#   while true:
+#     var sizeHex = ""
+#     if client.recv(sizeHex, 6) != 6:
+#       raise newException(ValueError, "didn't get all the hexbytes")
+#     var size = 0
+#     if parseHex(sizeHex, size) == 0:
+#       raise newException(ValueError, "invalid size hex: " & $sizeHex)
+#     var messageBuffer = ""
+#     if client.recv(messageBuffer, size) != size:
+#       raise newException(ValueError, "didn't get all the bytes")
+#     let
+#       message = parseSexp($messageBuffer)
+#       messageType = message[0].getSymbol
+#     case messageType:
+#     of "call":
+#       var results: seq[Suggest] = @[]
+#       suggestionResultHook = proc (s: Suggest) =
+#         results.add(s)
+
+#       let
+#         uid = message[1].getNum
+#         cmd = parseIdeCmd(message[2].getSymbol)
+#         args = message[3]
+#       executeEPC(cmd, args)
+#       returnEPC(client, uid, sexp(results))
+#     of "return":
+#       raise newException(EUnexpectedCommand, "no return expected")
+#     of "return-error":
+#       raise newException(EUnexpectedCommand, "no return expected")
+#     of "epc-error":
+#       stderr.writeline("recieved epc error: " & $messageBuffer)
+#       raise newException(IOError, "epc error")
+#     of "methods":
+#       returnEPC(client, message[1].getNum, listEPC())
+#     else:
+#       raise newException(EUnexpectedCommand, "unexpected call: " & messageType)

--- a/modes/commonMode.nim
+++ b/modes/commonMode.nim
@@ -1,14 +1,3 @@
-#
-#
-#           The Nim Compiler
-#        (c) Copyright 2015 Andreas Rumpf
-#
-#    See the file "copying.txt", included in this
-#    distribution, for details about the copyright.
-#
-
-## Nimsuggest is a tool that helps to give editors IDE like capabilities.
-
 import strutils, os, parseopt, parseutils, sequtils, net, rdstdin, ../sexp
 # Do NOT import suggest. It will lead to wierd bugs with
 # suggestionResultHook, because suggest.nim is included by sigmatch.
@@ -52,6 +41,7 @@ proc symFromInfo(gTrackPos: TLineInfo): PSym =
   if m != nil and m.ast != nil:
     result = m.ast.findNode
 
+
 proc execute*(cmd: IdeCmd, file, dirtyfile: string, line, col: int) =
   gIdeCmd = cmd
   if cmd == ideUse and suggestVersion != 2:
@@ -79,8 +69,7 @@ proc execute*(cmd: IdeCmd, file, dirtyfile: string, line, col: int) =
   if gIdeCmd in {ideUse, ideDus}:
     let u = if suggestVersion >= 2: symFromInfo(gTrackPos) else: usageSym
     if u != nil:
-      discard
-      # EpcModeData(u)
+      listUsages(u)
     else:
       localError(gTrackPos, "found no symbol at this position " & $gTrackPos)
 

--- a/modes/epcMode.nim
+++ b/modes/epcMode.nim
@@ -1,0 +1,162 @@
+import tables, net, parseopt2, strutils, parseutils, os, sequtils, rdstdin
+import ../nimsuggest, ../sexp, commonMode
+
+# Do NOT import suggest. It will lead to wierd bugs with
+# suggestionResultHook, because suggest.nim is included by sigmatch.
+# So we import that one instead.
+import compiler/options, compiler/commands, compiler/modules, compiler/sem,
+  compiler/passes, compiler/passaux, compiler/msgs, compiler/nimconf,
+  compiler/extccomp, compiler/condsyms, compiler/lists,
+  compiler/sigmatch, compiler/ast
+
+
+const epcModeHelpMsg = """
+Nimsuggest EPC Mode Switches:
+  -p, --port:port_no     Port to use to connect (defaults to 8000).
+  --address:"address"    Address to bind to. Defaults to ""
+"""
+
+
+type EpcModeData = ref object of ModeData
+  port: Port
+  address: string not nil
+  persist: bool
+
+
+proc initializeData*(): ModeData =
+  var res = new(EpcModeData)
+  res.port = Port(0)
+  res.address = ""
+  result = ModeData(res)
+
+type
+  EUnexpectedCommand = object of Exception
+
+proc addModes*(modes: var TableRef[string, ModeInitializer]) =
+  modes["epc"] = initializeData
+
+
+# ModeData Interface Methods
+method processSwitches(data: EpcModeData, switches: SwitchSequence) =
+  for switch in switches:
+    case switch.kind
+    of cmdLongOption, cmdShortOption:
+      case switch.key.normalize
+      of "p", "port":
+        try:
+          data.port = Port(parseInt(switch.value))
+        except ValueError:
+          quit("Invalid port:'" & switch.value & "'")
+      of "address":
+        data.address = switch.value
+      else:
+        echo("Invalid mode switch '$#'" % [switch.key])
+        quit()
+    else:
+      discard
+
+
+method echoOptions(data: EpcModeData) =
+  echo(epcModeHelpMsg)
+  quit()
+
+proc sexp(s: IdeCmd): SexpNode = sexp($s)
+
+proc sexp(s: TSymKind): SexpNode = sexp($s)
+
+proc sexp(s: Suggest): SexpNode =
+  # If you change the oder here, make sure to change it over in
+  # nim-mode.el too.
+  result = convertSexp([
+    s.section,
+    s.symkind,
+    s.qualifiedPath.map(newSString),
+    s.filePath,
+    s.forth,
+    s.line,
+    s.column,
+    s.doc
+  ])
+
+proc sexp(s: seq[Suggest]): SexpNode =
+  result = newSList()
+  for sug in s:
+    result.add(sexp(sug))
+
+
+
+
+
+
+
+
+proc listEPC(): SexpNode =
+  let
+    argspecs = sexp("file line column dirtyfile".split(" ").map(newSSymbol))
+    docstring = sexp("line starts at 1, column at 0, dirtyfile is optional")
+  result = newSList()
+  for command in ["sug", "con", "def", "use", "dus"]:
+    let
+      cmd = sexp(command)
+      methodDesc = newSList()
+    methodDesc.add(cmd)
+    methodDesc.add(argspecs)
+    methodDesc.add(docstring)
+    result.add(methodDesc)
+proc executeEPC(cmd: IdeCmd, args: SexpNode) =
+  let
+    file = args[0].getStr
+    line = args[1].getNum
+    column = args[2].getNum
+  var dirtyfile = ""
+  if len(args) > 3:
+    dirtyfile = args[3].getStr(nil)
+  execute(cmd, file, dirtyfile, int(line), int(column))
+
+proc returnEPC(socket: var Socket, uid: BiggestInt, s: SexpNode,
+               return_symbol = "return") =
+  let response = $convertSexp([newSSymbol(return_symbol), uid, s])
+  socket.send(toHex(len(response), 6))
+  socket.send(response)
+
+proc mainCommand(data: EpcModeData, server: Socket) =
+  var inp = "".TaintedString
+  var client = newSocket()
+  # Wait for connection
+  accept(server, client)
+  while true:
+    var sizeHex = ""
+    if client.recv(sizeHex, 6) != 6:
+      raise newException(ValueError, "didn't get all the hexbytes")
+    var size = 0
+    if parseHex(sizeHex, size) == 0:
+      raise newException(ValueError, "invalid size hex: " & $sizeHex)
+    var messageBuffer = ""
+    if client.recv(messageBuffer, size) != size:
+      raise newException(ValueError, "didn't get all the bytes")
+    let
+      message = parseSexp($messageBuffer)
+      messageType = message[0].getSymbol
+    case messageType:
+    of "call":
+      var results: seq[Suggest] = @[]
+      suggestionResultHook = proc (s: Suggest) =
+        results.add(s)
+
+      let
+        uid = message[1].getNum
+        cmd = parseIdeCmd(message[2].getSymbol)
+        args = message[3]
+      executeEPC(cmd, args)
+      returnEPC(client, uid, sexp(results))
+    of "return":
+      raise newException(EUnexpectedCommand, "no return expected")
+    of "return-error":
+      raise newException(EUnexpectedCommand, "no return expected")
+    of "epc-error":
+      stderr.writeline("recieved epc error: " & $messageBuffer)
+      raise newException(IOError, "epc error")
+    of "methods":
+      returnEPC(client, message[1].getNum, listEPC())
+    else:
+      raise newException(EUnexpectedCommand, "unexpected call: " & messageType)

--- a/modes/stdinMode.nim
+++ b/modes/stdinMode.nim
@@ -53,7 +53,7 @@ method echoOptions(data: StdinModeData) =
   quit()
 
 method mainCommand(data: StdinModeData) =
-  msgs.writelnHook = proc (msg: string) = discard
+  msgs.writelnHook = (proc (msg: string) = echo msg)
   let prefix = if data.interactive: "> " else: ""
   if data.interactive:
     echo("Running Nimsuggest Stdin Mode")
@@ -64,5 +64,5 @@ method mainCommand(data: StdinModeData) =
   while readLineFromStdin(prefix, line):
     flushFile(stdin)
     parseCmdLine line
-    echo ""
+    echo("\n")
     flushFile(stdout)

--- a/modes/stdinMode.nim
+++ b/modes/stdinMode.nim
@@ -22,11 +22,9 @@ type StdinModeData = ref object of ModeData
 
 proc initializeData*(): ModeData =
   var res = new(StdinModeData)
-
   result = ModeData(res)
 
-
-proc addModes*(modes: var TableRef[string, ModeInitializer]) =
+proc addModes*(modes: TableRef[string, ModeInitializer]) =
   modes["stdin"] = initializeData
 
 
@@ -44,18 +42,15 @@ method processSwitches(data: StdinModeData, switches: SwitchSequence) =
             data.interactive = parseBool(switch.value)
           except ValueError:
             quit("Invalid \"interactive\" value \"" & switch.value & "\"")
-
       else:
         echo("Invalid mode switch \"$#:$#\"" % [switch.key, switch.value])
         quit()
     else:
       discard
 
-
 method echoOptions(data: StdinModeData) =
   echo(stdinModeHelpMsg)
   quit()
-
 
 method mainCommand(data: StdinModeData) =
   msgs.writelnHook = proc (msg: string) = discard

--- a/modes/stdinMode.nim
+++ b/modes/stdinMode.nim
@@ -1,0 +1,73 @@
+import tables, net, parseopt2, strutils, rdstdin
+import ../nimsuggest, commonMode
+import compiler/msgs
+
+
+const stdinModeHelpMsg = """
+Nimsuggest Stdin Mode Switches:
+  -i, --interactive:[true|false]
+          Run in interactive mode, suitable for terminal use.       
+"""
+
+const interactiveHelpMsg = """
+Usage: sug|con|def|use|dus|chk|highlight|outline file.nim[;dirtyfile.nim]:line:col
+Type 'quit' to quit, 'debug' to toggle debug mode on/off, and 'terse'
+to toggle terse mode on/off.
+"""
+
+
+type StdinModeData = ref object of ModeData
+  interactive: bool
+
+
+proc initializeData*(): ModeData =
+  var res = new(StdinModeData)
+
+  result = ModeData(res)
+
+
+proc addModes*(modes: var TableRef[string, ModeInitializer]) =
+  modes["stdin"] = initializeData
+
+
+# ModeData Interface Methods
+method processSwitches(data: StdinModeData, switches: SwitchSequence) =
+  for switch in switches:
+    case switch.kind
+    of cmdLongOption, cmdShortOption:
+      case switch.key.normalize
+      of "interactive", "i":
+        if switch.value == "":
+          data.interactive = true
+        else:
+          try:
+            data.interactive = parseBool(switch.value)
+          except ValueError:
+            quit("Invalid \"interactive\" value \"" & switch.value & "\"")
+
+      else:
+        echo("Invalid mode switch \"$#:$#\"" % [switch.key, switch.value])
+        quit()
+    else:
+      discard
+
+
+method echoOptions(data: StdinModeData) =
+  echo(stdinModeHelpMsg)
+  quit()
+
+
+method mainCommand(data: StdinModeData) =
+  msgs.writelnHook = proc (msg: string) = discard
+  let prefix = if data.interactive: "> " else: ""
+  if data.interactive:
+    echo("Running Nimsuggest Stdin Mode")
+    echo("Project file: \"$#\"" % [data.projectPath])
+    echo interactiveHelpMsg
+
+  var line = ""
+  while readLineFromStdin(prefix, line):
+    flushFile(stdin)
+    parseCmdLine line
+    echo ""
+    flushFile(stdout)

--- a/modes/tcpMode.nim
+++ b/modes/tcpMode.nim
@@ -1,7 +1,7 @@
 import tables, net, parseopt2, strutils
 import ../nimsuggest, commonMode
 import compiler/msgs
-
+from os import nil
 
 const tcpModeHelpMsg = """
 Nimsuggest TCP Mode Switches:
@@ -91,7 +91,7 @@ proc serveAsServer(data: TcpModeData) =
     parseCmdLine inp.string
     stdoutSocket.send("\c\L")
 
-    if data.persist:
+    if not data.persist:
       stdoutSocket.close()
       setupStdoutSocket()
 
@@ -109,10 +109,13 @@ proc serveAsClient(data: TcpModeData) =
 
     try:
       stdoutSocket.readLine(input)
+      if input == "":
+        stdoutSocket = nil
+        continue
       parseCmdLine(string(input))
-      stdoutSocket.send("\c\l")
+      stdoutSocket.send("\c\l\c\l")
     except OSError:
-      stdoutSocket = nil
+      quit()
 
 method mainCommand(data: TcpModeData) =
   msgs.writelnHook = proc (msg: string) = discard

--- a/modes/tcpMode.nim
+++ b/modes/tcpMode.nim
@@ -26,8 +26,7 @@ proc initializeData*(): ModeData =
 
   result = ModeData(res)
 
-
-proc addModes*(modes: var TableRef[string, ModeInitializer]) =
+proc addModes*(modes: TableRef[string, ModeInitializer]) =
   modes["tcp"] = initializeData
 
 
@@ -52,18 +51,15 @@ method processSwitches(data: TcpModeData, switches: SwitchSequence) =
             data.persist = parseBool(switch.value)
           except ValueError:
             quit("Invalid 'persistance' value '" & switch.value & "'")
-
       else:
         echo("Invalid mode switch '$#'" % [switch.key])
         quit()
     else:
       discard
 
-
 method echoOptions(data: TcpModeData) =
   echo(tcpModeHelpMsg)
   quit()
-
 
 method mainCommand(data: TcpModeData) =
   msgs.writelnHook = proc (msg: string) = discard

--- a/modes/tcpMode.nim
+++ b/modes/tcpMode.nim
@@ -1,0 +1,90 @@
+import tables, net, parseopt2, strutils
+import ../nimsuggest, commonMode
+import compiler/msgs
+
+
+const tcpModeHelpMsg = """
+Nimsuggest TCP Mode Switches:
+  -p, --port:port_no         Port to use to connect (defaults to 8000).
+  --address:"address"        Address to bind to. Defaults to ""
+  --persist                  Create a persistant connection that isn't closed
+                             after the first completed command. Completed
+                             commands are then denoted by a newline.
+"""
+
+
+type TcpModeData = ref object of ModeData
+  port: Port
+  address: string not nil
+  persist: bool
+
+
+proc initializeData*(): ModeData =
+  var res = new(TcpModeData)
+  res.port = Port(0)
+  res.address = ""
+
+  result = ModeData(res)
+
+
+proc addModes*(modes: var TableRef[string, ModeInitializer]) =
+  modes["tcp"] = initializeData
+
+
+# ModeData Interface Methods
+method processSwitches(data: TcpModeData, switches: SwitchSequence) =
+  for switch in switches:
+    case switch.kind
+    of cmdLongOption, cmdShortOption:
+      case switch.key.normalize
+      of "p", "port":
+        try:
+          data.port = Port(parseInt(switch.value))
+        except ValueError:
+          quit("Invalid port:'" & switch.value & "'")
+      of "address":
+        data.address = switch.value
+      of "persist":
+        if switch.value == "":
+          data.persist = true
+        else:
+          try:
+            data.persist = parseBool(switch.value)
+          except ValueError:
+            quit("Invalid 'persistance' value '" & switch.value & "'")
+
+      else:
+        echo("Invalid mode switch '$#'" % [switch.key])
+        quit()
+    else:
+      discard
+
+
+method echoOptions(data: TcpModeData) =
+  echo(tcpModeHelpMsg)
+  quit()
+
+
+method mainCommand(data: TcpModeData) =
+  msgs.writelnHook = proc (msg: string) = discard
+  echo("Running Nimsuggest TCP Mode on port $#, address \"$#\"" % [$data.port, data.address])
+  echo("Project file: \"$#\"" % [data.projectPath])
+  var server = newSocket()
+  server.bindAddr(data.port, data.address)
+  var inp = "".TaintedString
+  server.listen()
+
+  while true:
+    var stdoutSocket = newSocket()
+    msgs.writelnHook = proc (line: string) =
+      stdoutSocket.send(line & "\c\L")
+
+    accept(server, stdoutSocket)
+
+    stdoutSocket.readLine(inp)
+    parseCmdLine inp.string
+
+    stdoutSocket.send("\c\L")
+    if not data.persist:
+      stdoutSocket.close()
+      server = newSocket()

--- a/nimsuggest.nim
+++ b/nimsuggest.nim
@@ -1,367 +1,155 @@
-#
-#
-#           The Nim Compiler
-#        (c) Copyright 2015 Andreas Rumpf
-#
-#    See the file "copying.txt", included in this
-#    distribution, for details about the copyright.
-#
+import tables, parseopt2, strutils, os, parseutils, sequtils, net, rdstdin, sexp
 
-## Nimsuggest is a tool that helps to give editors IDE like capabilities.
-
-import strutils, os, parseopt, parseutils, sequtils, net, rdstdin, sexp
-# Do NOT import suggest. It will lead to wierd bugs with
-# suggestionResultHook, because suggest.nim is included by sigmatch.
-# So we import that one instead.
 import compiler/options, compiler/commands, compiler/modules, compiler/sem,
   compiler/passes, compiler/passaux, compiler/msgs, compiler/nimconf,
   compiler/extccomp, compiler/condsyms, compiler/lists,
   compiler/sigmatch, compiler/ast
 
-when defined(windows):
-  import winlean
-else:
-  import posix
-
-const Usage = """
+const helpMsg = """
 Nimsuggest - Tool to give every editor IDE like capabilities for Nim
 Usage:
-  nimsuggest [options] projectfile.nim
+  nimsuggest [options] [mode] [mode_options] "path/to/projectfile.nim"
 
 Options:
-  --port:PORT             port, by default 6000
-  --address:HOST          binds to that address, by default ""
-  --stdin                 read commands from stdin and write results to
-                          stdout instead of using sockets
-  --epc                   use emacs epc mode
-  --debug                 enable debug output
-  --v2                    use version 2 of the protocol; more features and
-                          much faster
+  --nimPath:"path"      Set the path to the Nim compiler.
+  --v2                  Use protocol version 2       
+  --debug               Enable debug output on stdin.
+  --help                Print help output for the specified mode.
 
-The server then listens to the connection and takes line-based commands.
+Modes:
+  tcp            Use text-based input from a tcp socket.
+                 This is the default mode.
+  stdin          Use text-based input from stdin (interactive use)
+  epc            Use
 
 In addition, all command line options of Nim that do not affect code generation
-are supported.
+are supported. To pass a Nim compiler command-line argument, prefix it with
+"nim." when passing global options, for example:
+  nimsuggest --nim.define:release tcp projectfile.nim
 """
-type
-  Mode = enum mstdin, mtcp, mepc
-
-var
-  gPort = 6000.Port
-  gAddress = ""
-  gMode: Mode
-
-const
-  seps = {':', ';', ' ', '\t'}
-  Help = "usage: sug|con|def|use|dus|chk|highlight|outline file.nim[;dirtyfile.nim]:line:col\n" &
-         "type 'quit' to quit\n" &
-         "type 'debug' to toggle debug mode on/off\n" &
-         "type 'terse' to toggle terse mode on/off"
 
 type
-  EUnexpectedCommand = object of Exception
+  nnstring = string not nil
+  ModeData* = ref object of RootObj
+    mode*: string not nil
+    projectPath*: string not nil
+    nimsuggestVersion: int
 
-proc parseQuoted(cmd: string; outp: var string; start: int): int =
-  var i = start
-  i += skipWhitespace(cmd, i)
-  if cmd[i] == '"':
-    i += parseUntil(cmd, outp, '"', i+1)+2
+  ModeInitializer* = proc (): ModeData
+
+  SwitchSequence* = seq[
+    tuple[
+      kind: CmdLineKind,
+      key, value: string not nil
+    ]
+  ]
+
+  CmdLineData* = object
+    mode: string not nil
+    nimsuggestSwitches: SwitchSequence not nil
+    modeSwitches: SwitchSequence not nil
+    compilerSwitches: SwitchSequence not nil
+    projectPath: string not nil
+
+
+# ModeData Method Stubs
+method processSwitches(data: ModeData, switches: SwitchSequence) {.base.} =
+  raise newException(ValueError, "Mode doesn't implement processSwitches")
+
+method echoOptions(data: ModeData) {.base.} =
+  raise newException(ValueError, "Mode doesn't implement echoOptions")
+
+method mainCommand(data: ModeData) {.base.} =
+  raise newException(ValueError, "Mode doesn't implement mainCommand")
+
+
+# Import and add nimsuggest modes
+var modes = newTable[string, ModeInitializer]()
+
+import modes/tcpMode, modes/stdinMode, modes/epcmode
+tcpMode.addModes(modes)
+stdinMode.addModes(modes)
+epcmode.addModes(modes)
+
+# Command line logic
+proc badUsage(msg: string = nil) =
+  if not isNil(msg):
+    echo(msg)
+  quit()
+
+template ifNotNilElse(a, b, c: untyped): untyped =
+  let value = b
+  if value == nil:
+    a = c
   else:
-    i += parseUntil(cmd, outp, seps, i)
-  result = i
+    a = value
 
-proc sexp(s: IdeCmd): SexpNode = sexp($s)
+  
+import winlean
+proc gatherCmdLineData(): CmdLineData =
+  ## Gather the command line parameters into an CmdLineData object.
+  ## This works in two parts: we first get the global nimsuggest switches and
+  ## mode, then get the mode switches and project file.
+  var parser = initOptParser()
+  result = CmdLineData(
+      mode: "",
+      nimsuggestSwitches: @[],
+      modeSwitches: @[],
+      compilerSwitches: @[],
+      projectPath: ""
+    )
 
-proc sexp(s: TSymKind): SexpNode = sexp($s)
-
-proc sexp(s: Suggest): SexpNode =
-  # If you change the oder here, make sure to change it over in
-  # nim-mode.el too.
-  result = convertSexp([
-    s.section,
-    s.symkind,
-    s.qualifiedPath.map(newSString),
-    s.filePath,
-    s.forth,
-    s.line,
-    s.column,
-    s.doc
-  ])
-
-proc sexp(s: seq[Suggest]): SexpNode =
-  result = newSList()
-  for sug in s:
-    result.add(sexp(sug))
-
-proc listEPC(): SexpNode =
-  let
-    argspecs = sexp("file line column dirtyfile".split(" ").map(newSSymbol))
-    docstring = sexp("line starts at 1, column at 0, dirtyfile is optional")
-  result = newSList()
-  for command in ["sug", "con", "def", "use", "dus"]:
-    let
-      cmd = sexp(command)
-      methodDesc = newSList()
-    methodDesc.add(cmd)
-    methodDesc.add(argspecs)
-    methodDesc.add(docstring)
-    result.add(methodDesc)
-
-proc findNode(n: PNode): PSym =
-  #echo "checking node ", n.info
-  if n.kind == nkSym:
-    if isTracked(n.info, n.sym.name.s.len): return n.sym
-  else:
-    for i in 0 ..< safeLen(n):
-      let res = n.sons[i].findNode
-      if res != nil: return res
-
-proc symFromInfo(gTrackPos: TLineInfo): PSym =
-  let m = getModule(gTrackPos.fileIndex)
-  #echo m.isNil, " I knew it ", gTrackPos.fileIndex
-  if m != nil and m.ast != nil:
-    result = m.ast.findNode
-
-proc execute(cmd: IdeCmd, file, dirtyfile: string, line, col: int) =
-  gIdeCmd = cmd
-  if cmd == ideUse and suggestVersion != 2:
-    modules.resetAllModules()
-  var isKnownFile = true
-  let dirtyIdx = file.fileInfoIdx(isKnownFile)
-
-  if dirtyfile.len != 0: msgs.setDirtyFile(dirtyIdx, dirtyfile)
-  else: msgs.setDirtyFile(dirtyIdx, nil)
-
-  gTrackPos = newLineInfo(dirtyIdx, line, col)
-  gErrorCounter = 0
-  if suggestVersion < 2:
-    usageSym = nil
-  if not isKnownFile:
-    compileProject()
-  if suggestVersion == 2 and gIdeCmd in {ideDef, ideUse, ideDus} and
-      dirtyfile.len == 0:
-    discard "no need to recompile anything"
-  else:
-    resetModule dirtyIdx
-    if dirtyIdx != gProjectMainIdx:
-      resetModule gProjectMainIdx
-    compileProject(dirtyIdx)
-  if gIdeCmd in {ideUse, ideDus}:
-    let u = if suggestVersion >= 2: symFromInfo(gTrackPos) else: usageSym
-    if u != nil:
-      listUsages(u)
-    else:
-      localError(gTrackPos, "found no symbol at this position " & $gTrackPos)
-
-proc executeEPC(cmd: IdeCmd, args: SexpNode) =
-  let
-    file = args[0].getStr
-    line = args[1].getNum
-    column = args[2].getNum
-  var dirtyfile = ""
-  if len(args) > 3:
-    dirtyfile = args[3].getStr(nil)
-  execute(cmd, file, dirtyfile, int(line), int(column))
-
-proc returnEPC(socket: var Socket, uid: BiggestInt, s: SexpNode,
-               return_symbol = "return") =
-  let response = $convertSexp([newSSymbol(return_symbol), uid, s])
-  socket.send(toHex(len(response), 6))
-  socket.send(response)
-
-proc connectToNextFreePort(server: Socket, host: string, start = 30000): int =
-  result = start
+  # Get the nimsuggest switches and mode
   while true:
-    try:
-      server.bindaddr(Port(result), host)
-      return
-    except OsError:
-      when defined(windows):
-        let checkFor = WSAEADDRINUSE.OSErrorCode
+    parser.next()
+    echo(parser.key)
+    case parser.kind
+    of cmdLongOption, cmdShortOption:
+      # We filter global switches here to allow the user to pass
+      # switches to the compiler.
+      if parser.key.startsWith("nim."):
+        result.compilerSwitches.add(
+          (parser.kind, nnstring(parser.key[4..^1]), nnstring(parser.val))
+        )
       else:
-        let checkFor = EADDRINUSE.OSErrorCode
-      if osLastError() != checkFor:
-        raise getCurrentException()
-      else:
-        result += 1
-
-proc parseCmdLine(cmd: string) =
-  template toggle(sw) =
-    if sw in gGlobalOptions:
-      excl(gGlobalOptions, sw)
-    else:
-      incl(gGlobalOptions, sw)
-    return
-
-  template err() =
-    echo Help
-    return
-
-  var opc = ""
-  var i = parseIdent(cmd, opc, 0)
-  case opc.normalize
-  of "sug": gIdeCmd = ideSug
-  of "con": gIdeCmd = ideCon
-  of "def": gIdeCmd = ideDef
-  of "use": gIdeCmd = ideUse
-  of "dus": gIdeCmd = ideDus
-  of "chk":
-    gIdeCmd = ideChk
-    incl(gGlobalOptions, optIdeDebug)
-  of "highlight": gIdeCmd = ideHighlight
-  of "outline": gIdeCmd = ideOutline
-  of "quit": quit()
-  of "debug": toggle optIdeDebug
-  of "terse": toggle optIdeTerse
-  else: err()
-  var dirtyfile = ""
-  var orig = ""
-  i = parseQuoted(cmd, orig, i)
-  if cmd[i] == ';':
-    i = parseQuoted(cmd, dirtyfile, i+1)
-  i += skipWhile(cmd, seps, i)
-  var line = -1
-  var col = 0
-  i += parseInt(cmd, line, i)
-  i += skipWhile(cmd, seps, i)
-  i += parseInt(cmd, col, i)
-
-  execute(gIdeCmd, orig, dirtyfile, line, col-1)
-
-proc serveStdin() =
-  echo Help
-  var line = ""
-  while readLineFromStdin("> ", line):
-    parseCmdLine line
-    echo ""
-    flushFile(stdout)
-
-proc serveTcp() =
-  var server = newSocket()
-  server.bindAddr(gPort, gAddress)
-  var inp = "".TaintedString
-  server.listen()
-
-  while true:
-    var stdoutSocket = newSocket()
-    msgs.writelnHook = proc (line: string) =
-      stdoutSocket.send(line & "\c\L")
-
-    accept(server, stdoutSocket)
-
-    stdoutSocket.readLine(inp)
-    parseCmdLine inp.string
-
-    stdoutSocket.send("\c\L")
-    stdoutSocket.close()
-
-proc serveEpc(server: Socket) =
-  var inp = "".TaintedString
-  var client = newSocket()
-  # Wait for connection
-  accept(server, client)
-  while true:
-    var sizeHex = ""
-    if client.recv(sizeHex, 6) != 6:
-      raise newException(ValueError, "didn't get all the hexbytes")
-    var size = 0
-    if parseHex(sizeHex, size) == 0:
-      raise newException(ValueError, "invalid size hex: " & $sizeHex)
-    var messageBuffer = ""
-    if client.recv(messageBuffer, size) != size:
-      raise newException(ValueError, "didn't get all the bytes")
-    let
-      message = parseSexp($messageBuffer)
-      messageType = message[0].getSymbol
-    case messageType:
-    of "call":
-      var results: seq[Suggest] = @[]
-      suggestionResultHook = proc (s: Suggest) =
-        results.add(s)
-
-      let
-        uid = message[1].getNum
-        cmd = parseIdeCmd(message[2].getSymbol)
-        args = message[3]
-      executeEPC(cmd, args)
-      returnEPC(client, uid, sexp(results))
-    of "return":
-      raise newException(EUnexpectedCommand, "no return expected")
-    of "return-error":
-      raise newException(EUnexpectedCommand, "no return expected")
-    of "epc-error":
-      stderr.writeline("recieved epc error: " & $messageBuffer)
-      raise newException(IOError, "epc error")
-    of "methods":
-      returnEPC(client, message[1].getNum, listEPC())
-    else:
-      raise newException(EUnexpectedCommand, "unexpected call: " & messageType)
-
-proc mainCommand =
-  registerPass verbosePass
-  registerPass semPass
-  gCmd = cmdIdeTools
-  incl gGlobalOptions, optCaasEnabled
-  isServing = true
-  wantMainModule()
-  appendStr(searchPaths, options.libpath)
-  if gProjectFull.len != 0:
-    # current path is always looked first for modules
-    prependStr(searchPaths, gProjectPath)
-
-  # do not stop after the first error:
-  msgs.gErrorMax = high(int)
-
-  case gMode
-  of mstdin:
-    compileProject()
-    serveStdin()
-  of mtcp:
-    # until somebody accepted the connection, produce no output (logging is too
-    # slow for big projects):
-    msgs.writelnHook = proc (msg: string) = discard
-    compileProject()
-    serveTcp()
-  of mepc:
-    var server = newSocket()
-    let port = connectToNextFreePort(server, "localhost")
-    server.listen()
-    echo port
-    compileProject()
-    serveEpc(server)
-
-proc processCmdLine*(pass: TCmdLinePass, cmd: string) =
-  var p = parseopt.initOptParser(cmd)
-  while true:
-    parseopt.next(p)
-    case p.kind
-    of cmdEnd: break
-    of cmdLongoption, cmdShortOption:
-      case p.key.normalize
-      of "port":
-        gPort = parseInt(p.val).Port
-        gMode = mtcp
-      of "address":
-        gAddress = p.val
-        gMode = mtcp
-      of "stdin": gMode = mstdin
-      of "epc":
-        gMode = mepc
-        gVerbosity = 0          # Port number gotta be first.
-      of "debug":
-        incl(gGlobalOptions, optIdeDebug)
-      of "v2":
-        suggestVersion = 2
-      else: processSwitch(pass, p)
+        result.nimsuggestSwitches.add(
+          (parser.kind, nnstring(parser.key), nnstring(parser.val))
+        )
     of cmdArgument:
-      options.gProjectName = unixToNativePath(p.key)
-      # if processArgument(pass, p, argsCount): break
+      ifNotNilElse(result.mode, parser.key, "")
+      break
+    of cmdEnd:
+      break
 
-proc handleCmdLine() =
-  if paramCount() == 0:
-    stdout.writeline(Usage)
-  else:
-    processCmdLine(passCmd1, "")
+  # Process the remaining mode switches and project file.
+  echo(getCommandLineW())
+  while true:
+    parser.next()
+    echo(parser.key)
+    case parser.kind:
+    of cmdLongOption, cmdShortOption:
+      result.modeSwitches.add(
+        (parser.kind, nnstring(parser.key), nnstring(parser.val))
+      )
+    of cmdArgument:
+      # Grab the project file and exit
+      ifNotNilElse(result.projectPath, parser.key, "")
+      break
+    of cmdEnd:
+      break
+
+  # Ensure that there are no remaining arguments
+  parser.next()
+  if parser.kind != cmdEnd:
+    badUsage("Error: Extra switches after project file.")
+
+
+proc setupCompiler(projectPath: string) =
+    condsyms.initDefines()
+    defineSymbol "nimsuggest"
+
+    gProjectName = projectPath
+    echo(projectPath)
     if gProjectName != "":
       try:
         gProjectFull = canonicalizePath(gProjectName)
@@ -380,19 +168,78 @@ proc handleCmdLine() =
           "Cannot find Nim standard library: Nim compiler not in PATH")
     gPrefixDir = binaryPath.splitPath().head.parentDir()
 
+    # Load the configuration files
     loadConfigs(DefaultConfig) # load all config files
-    # now process command line arguments again, because some options in the
-    # command line can overwite the config file's settings
+
     extccomp.initVars()
-    processCmdLine(passCmd2, "")
-    mainCommand()
+    registerPass verbosePass
+    registerPass semPass
 
-when false:
-  proc quitCalled() {.noconv.} =
-    writeStackTrace()
+    gCmd = cmdIdeTools
+    gGlobalOptions.incl(optCaasEnabled)
+    isServing = true
+    msgs.gErrorMax = high(int)
 
-  addQuitProc(quitCalled)
+    wantMainModule()
+    appendStr(searchPaths, options.libpath)
+    if gProjectFull.len != 0:
+      # current path is always looked first for modules
+      prependStr(searchPaths, gProjectPath)
 
-condsyms.initDefines()
-defineSymbol "nimsuggest"
-handleCmdline()
+proc main =
+  if paramCount() == 0:
+    echo(helpMsg)
+    quit()
+
+  # Gather and process command line data
+  var cmdLineData = gatherCmdLineData()
+  if not modes.hasKey(cmdLineData.mode.normalize()):
+    badUsage("Error: Unknown mode '" & cmdLineData.mode & "'")
+
+  # Initialize the mode and process global switches.
+  let modeInitializer = modes[cmdLineData.mode.normalize()]
+  var data = modeInitializer()
+  data.projectPath = cmdLineData.projectPath
+
+  # Process the nimsuggest switches
+  for switch in cmdLineData.nimsuggestSwitches:
+    case switch.kind
+    of cmdLongOption:
+      case switch.key.normalize
+      of "help", "h":
+        echo(helpMsg)
+        data.echoOptions()
+        quit()
+      of "v2":
+        suggestVersion = 2
+      else:
+        quit("Invalid switch '$#:$#'" % [switch.key, switch.value])
+    else:
+      quit("Invalid switch '$#:$#'" % [switch.key, switch.value])
+
+  # Check for project path here. Checking any earlier leads to --help not
+  # working without a project path.
+  if cmdLineData.projectPath == "":
+    badUsage("Error: Project path not supplied")
+
+  # Process the mode switches
+  data.processSwitches(cmdLineData.modeSwitches)
+
+  # Process the compiler switches
+  for switch in cmdLineData.compilerSwitches:
+    commands.processSwitch(switch.key, switch.value, passCmd1, gCmdLineInfo)
+
+  # Initialize Environment
+  setupCompiler(cmdLineData.projectPath)
+
+  # Process the command line again, as some parts may have been overridden by
+  # configuration files.
+  for switch in cmdLineData.compilerSwitches:
+    commands.processSwitch(switch.key, switch.value, passCmd2, gCmdLineInfo)
+
+  sleep(100)
+  data.mainCommand()
+
+suggestVersion = 2
+when isMainModule:
+  main()

--- a/nimsuggest.nim
+++ b/nimsuggest.nim
@@ -5,7 +5,9 @@ import compiler/options, compiler/commands, compiler/modules, compiler/sem,
   compiler/extccomp, compiler/condsyms, compiler/lists,
   compiler/sigmatch, compiler/ast
 
-const helpMsg = """
+const 
+  nimsuggestVersion = "0.1.0"
+  helpMsg = """
 Nimsuggest - Tool to give every editor IDE like capabilities for Nim
 Usage:
   nimsuggest [options] [mode] [mode_options] "path/to/projectfile.nim"
@@ -13,8 +15,9 @@ Usage:
 Options:
   --nimPath:"path"      Set the path to the Nim compiler.
   --v2                  Use protocol version 2       
-  --debug               Enable debug output on stdin.
+  --debug               Enable debug output.
   --help                Print help output for the specified mode.
+  --version             Print nimsuggest version to stdout, then quit.
 
 Modes:
   tcp            Use text-based input from a tcp socket.
@@ -34,7 +37,7 @@ type
   ModeData* = ref object of RootObj
     mode*: nnstring
     projectPath*: nnstring
-    nimsuggestVersion: int
+    protocolVersion: int
 
   ModeInitializer* = proc (): ModeData
 
@@ -211,6 +214,9 @@ proc main =
         quit()
       of "v2":
         suggestVersion = 2
+      of "version":
+        echo(nimsuggestVersion)
+        quit()
       else:
         quit("Invalid switch '$#:$#'" % [switch.key, switch.value])
     else:


### PR DESCRIPTION
Refactored and restructured nimsuggest.
The main changes are in how command-line arguments are parsed, and how modes are internally handled.

The command line is now split into 4 distinct parts: global switches, mode, mode switches, and project file. Global switches affect the running of Nimsuggest, and are mode-agnostic. Mode switches are specific to each mode, and control operation of that mode. Compiler switches are supported through 'nim.' prefixed switches in the global switches section. These changes allow for a more formulaic construction of command line invocations by editors, and help prevent possible switch collisions.

Modes are now comprised of a set of methods acting on a sub-type of `ModeData`. At runtime, a `ModeData` initializer corresponding to each mode is added into a table keyed to the mode's name. This table is then searched for the mode given on the command line, and the various methods attached to the underlying `ModeData` type are used to handled parts of Nimsuggest. Though there is a run time cost associated with the change in models, this new architecture allows clean separation between core and mode-specific logic, and makes adding new modes much simpler.

This is a backwards incompatible change, however given the fact that this is primarily a tool used by other programs, the changes aren't as severe as they normally would be - it's quite a bit easier to change program code than to change someone's habits.