### PR TITLE
apply `chk` option for EPC

### DIFF
--- a/nimsuggest.nim
+++ b/nimsuggest.nim
@@ -267,14 +267,15 @@ proc serveEpc(server: Socket) =
       messageType = message[0].getSymbol
     case messageType:
     of "call":
-      var results: seq[Suggest] = @[]
-      suggestionResultHook = proc (s: Suggest) =
-        results.add(s)
-
       let
         uid = message[1].getNum
         cmd = parseIdeCmd(message[2].getSymbol)
         args = message[3]
+
+      var results: seq[Suggest] = @[]
+      suggestionResultHook = proc (s: Suggest) =
+        results.add(s)
+
       executeEPC(cmd, args)
       returnEPC(client, uid, sexp(results))
     of "return":

--- a/nimsuggest.nim
+++ b/nimsuggest.nim
@@ -73,7 +73,7 @@ proc parseQuoted(cmd: string; outp: var string; start: int): int =
 proc sexp(s: IdeCmd|TSymKind): SexpNode = sexp($s)
 
 proc sexp(s: Suggest): SexpNode =
-  # If you change the oder here, make sure to change it over in
+  # If you change the order here, make sure to change it over in
   # nim-mode.el too.
   result = convertSexp([
     s.section,

--- a/nimsuggest.nim
+++ b/nimsuggest.nim
@@ -269,14 +269,14 @@ proc serveEpc(server: Socket) =
     of "call":
       let
         uid = message[1].getNum
-        cmd = parseIdeCmd(message[2].getSymbol)
         args = message[3]
 
+      gIdeCmd = parseIdeCmd(message[2].getSymbol)
       var results: seq[Suggest] = @[]
       suggestionResultHook = proc (s: Suggest) =
         results.add(s)
 
-      executeEPC(cmd, args)
+      executeEPC(gIdeCmd, args)
       returnEPC(client, uid, sexp(results))
     of "return":
       raise newException(EUnexpectedCommand, "no return expected")

--- a/nimsuggest.nim
+++ b/nimsuggest.nim
@@ -70,9 +70,7 @@ proc parseQuoted(cmd: string; outp: var string; start: int): int =
     i += parseUntil(cmd, outp, seps, i)
   result = i
 
-proc sexp(s: IdeCmd): SexpNode = sexp($s)
-
-proc sexp(s: TSymKind): SexpNode = sexp($s)
+proc sexp(s: IdeCmd|TSymKind): SexpNode = sexp($s)
 
 proc sexp(s: Suggest): SexpNode =
   # If you change the oder here, make sure to change it over in

--- a/nimsuggest.nim
+++ b/nimsuggest.nim
@@ -92,11 +92,12 @@ proc sexp(s: seq[Suggest]): SexpNode =
     result.add(sexp(sug))
 
 proc listEPC(): SexpNode =
+  # This function is called from Emacs to show available options.
   let
     argspecs = sexp("file line column dirtyfile".split(" ").map(newSSymbol))
     docstring = sexp("line starts at 1, column at 0, dirtyfile is optional")
   result = newSList()
-  for command in ["sug", "con", "def", "use", "dus"]:
+  for command in ["sug", "con", "def", "use", "dus", "chk"]:
     let
       cmd = sexp(command)
       methodDesc = newSList()

--- a/nimsuggest.nim
+++ b/nimsuggest.nim
@@ -267,7 +267,6 @@ proc serveTcp() =
     stdoutSocket.close()
 
 proc serveEpc(server: Socket) =
-  var inp = "".TaintedString
   var client = newSocket()
   # Wait for connection
   accept(server, client)

--- a/nimsuggest.nim
+++ b/nimsuggest.nim
@@ -278,8 +278,8 @@ proc serveEpc(server: Socket) =
     checkSanity(client, sizeHex, size, messageBuffer)
     let
       message = parseSexp($messageBuffer)
-      messageType = message[0].getSymbol
-    case messageType:
+      epcAPI = message[0].getSymbol
+    case epcAPI:
     of "call":
       let
         uid = message[1].getNum
@@ -305,11 +305,11 @@ proc serveEpc(server: Socket) =
       stderr.writeline("recieved epc error: " & $messageBuffer)
       raise newException(IOError, "epc error")
     else:
-      let errMessage = case messageType
+      let errMessage = case epcAPI
                        of "return", "return-error":
                          "no return expected"
                        else:
-                         "unexpected call: " & messageType
+                         "unexpected call: " & epcAPI
       raise newException(EUnexpectedCommand, errMessage)
 
 proc mainCommand =

--- a/nimsuggest.nim
+++ b/nimsuggest.nim
@@ -186,6 +186,9 @@ template checkSanity(client, sizeHex, size, messageBuffer: typed) =
   if client.recv(messageBuffer, size) != size:
     raise newException(ValueError, "didn't get all the bytes")
 
+template setVerbosity(level: typed) =
+  gVerbosity = level
+  gNotes = NotesVerbosity[gVerbosity]
 
 proc connectToNextFreePort(server: Socket, host: string): Port =
   server.bindaddr(Port(0), host)
@@ -292,6 +295,7 @@ proc serveEpc(server: Socket) =
         var hints_or_errors = ""
         sendEPC(hints_or_errors, string, msgs.writelnHook)
       of ideSug, ideCon, ideDef, ideUse, ideDus:
+        setVerbosity(0)
         var suggests: seq[Suggest] = @[]
         sendEPC(suggests, Suggest, suggestionResultHook)
       else: discard

--- a/nimsuggest.nim
+++ b/nimsuggest.nim
@@ -278,17 +278,18 @@ proc serveEpc(server: Socket) =
 
       executeEPC(gIdeCmd, args)
       returnEPC(client, uid, sexp(results))
-    of "return":
-      raise newException(EUnexpectedCommand, "no return expected")
-    of "return-error":
-      raise newException(EUnexpectedCommand, "no return expected")
+    of "methods":
+      returnEPC(client, message[1].getNum, listEPC())
     of "epc-error":
       stderr.writeline("recieved epc error: " & $messageBuffer)
       raise newException(IOError, "epc error")
-    of "methods":
-      returnEPC(client, message[1].getNum, listEPC())
     else:
-      raise newException(EUnexpectedCommand, "unexpected call: " & messageType)
+      let errMessage = case messageType
+                       of "return", "return-error":
+                         "no return expected"
+                       else:
+                         "unexpected call: " & messageType
+      raise newException(EUnexpectedCommand, errMessage)
 
 proc mainCommand =
   registerPass verbosePass

--- a/nimsuggest.nim
+++ b/nimsuggest.nim
@@ -290,6 +290,7 @@ proc serveEpc(server: Socket) =
 
       case gIdeCmd
       of ideChk:
+        setVerbosity(1)
         # Use full path because other emacs plugins depends it
         gListFullPaths = true
         incl(gGlobalOptions, optIdeDebug)


### PR DESCRIPTION
This PR apply `chk` option for EPC. (Emacs RPC)

My main purpose is allowing Emacs to asynchronous syntax check and
syntax check for nimscript files. (https://github.com/nim-lang/Nim/issues/3858)

something like:
![screenshot from 2016-03-19 18 10 28](https://cloud.githubusercontent.com/assets/1082473/13902270/fd5a3228-edff-11e5-89f9-310de367ad26.png)

(I can make pull request for nim-mode as well)